### PR TITLE
Issue 24 pre commit helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Added
 
-- ~~Added command that formats/prettify all `.tf`-files in directory #21~~
+- Added command that formats/prettify all `.tf`-files in directory #21 (overwritten by #24)
 - Added check for consul and terraform binary in the `Makefile` #20
 - Added `make pre-commit` command that use local linter and formatts/prettyfies all `.tf` files #24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 - ~~Added command that formats/prettify all `.tf`-files in directory #21~~
 - Added check for consul and terraform binary in the `Makefile` #20
-- Added pre-commit command that use local linter and formatts/prettyfies all `.tf` files #24
+- Added `make pre-commit` command that use local linter and formatts/prettyfies all `.tf` files #24
+- Squashed `make linter` and `make prettify` into `make pre-commit`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - ~~Added command that formats/prettify all `.tf`-files in directory #21~~
 - Added check for consul and terraform binary in the `Makefile` #20
 - Added `make pre-commit` command that use local linter and formatts/prettyfies all `.tf` files #24
-- Squashed `make linter` and `make prettify` into `make pre-commit`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 
 ### Added
 
-- Added command that formats/prettify all `.tf`-files in directory #21
+- ~~Added command that formats/prettify all `.tf`-files in directory #21~~
 - Added check for consul and terraform binary in the `Makefile` #20
+- Added pre-commit command that use local linter and formatts/prettyfies all `.tf` files #24
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ There are several commands that help to run the vagrant-box:
 
 - `make template_example` runs the example in [template_example/](template_example).
 
-- `make pre-commit` this is a helper command that will run the github linter locally and formatt/prettify all the `.tf` files in the directory.  
+- `make pre-commit` this is a helper command that will run the github linter locally and formatt/prettify all the `.tf` files in the directory.
 
 > :bulb: For full info, check [`template/Makefile`](./Makefile).
 > :warning: Makefile commands are not idempotent in the context of vagrant-box.  You could face the error of port collisions. Most of the cases it could happen because of the vagrant box has already been running. Run `vagrant destroy -f` to destroy the box.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,9 @@ There are several commands that help to run the vagrant-box:
 
 - `make update` downloads the newest version of the [vagrant-hashistack box](https://github.com/fredrikhgrelland/vagrant-hashistack/) from [vagrantcloud](https://vagrantcloud.com/fredrikhgrelland/hashistack).
 
-- `make template_example` runs the example in [template_example/](template_example)
+- `make template_example` runs the example in [template_example/](template_example).
+
+- `make pre-commit` this is a helper command that will run the github linter locally and formatt/prettify all the `.tf` files in the directory.  
 
 > :bulb: For full info, check [`template/Makefile`](./Makefile).
 > :warning: Makefile commands are not idempotent in the context of vagrant-box.  You could face the error of port collisions. Most of the cases it could happen because of the vagrant box has already been running. Run `vagrant destroy -f` to destroy the box.


### PR DESCRIPTION
Closes #24 

- Added `make pre-commit` command that uses the github linter and formats `.tf` files
- Squashed `make linter` and  `make prettier` into `make pre-commit`