### PR TITLE
Dynamic use of consul_token

### DIFF
--- a/template_example/dev/ansible/00_create_intention.yml
+++ b/template_example/dev/ansible/00_create_intention.yml
@@ -1,6 +1,6 @@
 - name: set variable
   set_fact:
-    consul_token: "master"
+    consul_token: "{{ lookup('env', 'consul_master_token') }}"
 
 - name: Check if intention count-dashboard => count-api (allow) exists
   shell: consul intention match -source count-dashboard

--- a/template_example/dev/ansible/03_healthcheck_test.yml
+++ b/template_example/dev/ansible/03_healthcheck_test.yml
@@ -1,6 +1,6 @@
 - name: set variable
   set_fact:
-    consul_token: "master"
+    consul_token: "{{ lookup('env', 'consul_master_token') }}"
   tags: test
 
 - name: countdash healthcheck test without consul token (when consul acl default policy is allow)
@@ -33,8 +33,8 @@
     - lookup('env', 'consul_acl') | bool
     - lookup('env', 'consul_acl_default_policy') == 'deny'
   register: result_countdashboard
-  retries: 1
-  delay: 1
+  retries: 15
+  delay: 15
   until:
     - result_countdashboard.json | length == 1
     - '"warning" not in result_countdashboard | string'

--- a/template_example/example/standalone/providers.tf
+++ b/template_example/example/standalone/providers.tf
@@ -12,7 +12,8 @@ provider "nomad" {
 
 provider "vault" {
   address = "http://127.0.0.1:8200"
-  token   = "master"
+  # Terraform imports TF_VAR_vault_master_token from the box env
+  token   = var.vault_master_token
 }
 
 terraform {

--- a/template_example/example/standalone/variables.tf
+++ b/template_example/example/standalone/variables.tf
@@ -2,3 +2,8 @@ variable "nomad_acl" {
   type        = bool
   description = "Nomad ACLs enabled/disabled"
 }
+
+variable "vault_master_token" {
+  type        = string
+  description = "Vault master token"
+}


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
No issue.

## What was added/changed/fixed?
Dynamic use of consul token in Ansible script. Was hardcoded to `master`.

## Related issue(s)? [Optional]
This needs to be merge before we can close [vagrant-hashistack issue #394](https://github.com/fredrikhgrelland/vagrant-hashistack/issues/394)

## Others [Optional]

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [x] Added to project
- [x] Added to milestone
- Need to update documentation? (Y/n) **no**